### PR TITLE
Fix bonus task by adding sleep between IPFS pulls and prolonging the round time

### DIFF
--- a/config-task.yml
+++ b/config-task.yml
@@ -46,15 +46,15 @@ task_audit_program: "dist/main.js"
 ## Round Time ##
 # Duration of task, measured in slots (with each slot approximately equal to 408ms). Should be at least 800 slots.
 # See https://www.koii.network/docs/concepts/what-are-tasks/what-are-tasks/gradual-consensus for more information on how round time, audit window, and submission window work.
-round_time: 2000
+round_time: 16000
 
 ## Audit Window ##
 # The audit window should be at least 1/3 of the round time.
-audit_window: 800
+audit_window: 6400
 
 ## Submission Window ##
 # The submission window should be at least 1/3 of the round time.
-submission_window: 1200
+submission_window: 9600
 
 ## Minimum Stake Amount ##
 # The minimum amount of KOII that a user must stake in order to participate in the task.
@@ -76,7 +76,7 @@ total_bounty_amount: 50000
 ## Bounty Amount per Round ##
 # The maximum amount that can be distributed per round.
 # If the actual distribution per round exceeds this amount, the distribution list will fail.
-bounty_amount_per_round: 500
+bounty_amount_per_round: 4000
 
 ## Allowed Failed Distributions ##
 # Number of retries allowed for the distribution list if it is fails audit.

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -6,7 +6,7 @@ export const COLLECTION_NAME = "stakingwallets";
 export const DB_BATCH_SIZE = 500;
 export const IS_TESTING = false;
 export const TESTING_BATCH_LIMIT = 5;
-export const REWARD_PER_ROUND = 500000000000;
+export const REWARD_PER_ROUND = 4000000000000;
 
 export const KOII_PROGRAM_ACCOUNT =
   "Koiitask22222222222222222222222222222222222";

--- a/src/task/4-distribution.js
+++ b/src/task/4-distribution.js
@@ -96,7 +96,7 @@ export async function distribution(submitters, bounty, roundNumber) {
       
       const cid = currentSubmission[key].submission_value;
       console.log(`Processing submission for ${key} with CID: ${cid}`);
-
+      await new Promise(r => setTimeout(r, 1000));
       try {
         const cidData = await getDataFromCID("distribution_proposal.json", cid);
         if (!cidData || !cidData.distribution_proposal || !cidData.distribution_proposal.getStakingKeys) {


### PR DESCRIPTION
Bug:
Koii IPFS gateway blocks any client after getting 10 submissions in a row, what makes the task impossible to complete the distribution list when there is a lot of submissions.

Fix:
Making sure that the task will have enough time to create a distribution list while not getting erorr HTTP STATUS 429 (Too Many Requests) from the Koii IPFS gateway. This fix should be good for a theoretical maximum of 7200 submissions per round, counting: 2h * 60min * 60sec divided by 1 IPFS download per second during the distribution phase. 

The fix maintains 50k Koii a day, just multiplies the slots needed for the round by 8 and adds a wait time not to DDOS Koii servers.