### PR TITLE
Better fix for the bonus task by not querying IPFS during distribution, by relying on audit function

### DIFF
--- a/src/task/2-submission.js
+++ b/src/task/2-submission.js
@@ -42,7 +42,14 @@ export async function submission(roundNumber) {
     const getCID = await getSubmissionCID(getFilePath);
 
     console.log("submission completed");
-    return getCID;
+
+    const saveOnChain = JSON.stringify({
+      cid: getCID,
+      acc1: getStakingKeys.getKoiiStakingKey,
+      acc2: getStakingKeys.getKPLStakingKey
+    });
+
+    return saveOnChain;
   } catch (error) {
     console.error("MAKE SUBMISSION ERROR:", error);
   }

--- a/src/task/3-audit.js
+++ b/src/task/3-audit.js
@@ -9,7 +9,7 @@ export async function audit(submission, roundNumber, submitterKey) {
   console.log(`AUDIT SUBMISSION FOR ROUND ${roundNumber} from ${submitterKey}`);
 
   try {
-    const cid = submission;
+    const cid = submission.cid;
     // Fetch and validate the data
     const data = await getDataFromCID("distribution_proposal.json", cid);
     if (

--- a/src/task/4-distribution.js
+++ b/src/task/4-distribution.js
@@ -94,11 +94,11 @@ export async function distribution(submitters, bounty, roundNumber) {
         continue;
       }
       
-      const savedOnChain = currentSubmission[key].submission_value;
+      const submission = currentSubmission[key].submission_value;
       console.log(`Processing submission for ${key} with CID: ${cid}`);
 
       try {
-        const { cid, acc1: getKoiiStakingKey, acc2: getKPLStakingKey} = savedOnChain;
+        const { cid, acc1: getKoiiStakingKey, acc2: getKPLStakingKey} = submission;
         
         if (!cid || cid.substr(0,7) !== 'bafybei') {
           console.log("Invalid or missing data in CID response");

--- a/src/task/4-distribution.js
+++ b/src/task/4-distribution.js
@@ -94,18 +94,16 @@ export async function distribution(submitters, bounty, roundNumber) {
         continue;
       }
       
-      const cid = currentSubmission[key].submission_value;
+      const savedOnChain = currentSubmission[key].submission_value;
       console.log(`Processing submission for ${key} with CID: ${cid}`);
 
       try {
-        const cidData = await getDataFromCID("distribution_proposal.json", cid);
-        if (!cidData || !cidData.distribution_proposal || !cidData.distribution_proposal.getStakingKeys) {
+        const { cid, acc1: getKoiiStakingKey, acc2: getKPLStakingKey} = savedOnChain;
+        
+        if (!cid || cid.substr(0,7) !== 'bafybei') {
           console.log("Invalid or missing data in CID response");
           continue;
         }
-
-        const { getKoiiStakingKey, getKPLStakingKey } =
-          cidData.distribution_proposal.getStakingKeys;
 
         console.log("Checking KOII wallet:", getKoiiStakingKey);
         console.log("Checking KPL wallet:", getKPLStakingKey);


### PR DESCRIPTION
This PR fixes the Bonus task in a better way than PR https://github.com/koii-network/bonus-task/pull/17 that I proposed yesterday.

Bug:
Koii IPFS gateway blocks any client after getting 10 submissions in a row, what makes the task impossible to complete the distribution list when there is a lot of submissions.

Fix:
1. During submission phase: save on chain not only cid of the submission, but also the staking keys.
2. During distribution phase: get staking keys for all submitters from a single RPC call instead of DDOSing Koii IPFS servers by 1000+ calls to IPFS. 

Important:
We do not need to rely on getting data from the IPFS to check if the submission of a node was valid, as we already do it in the audit phase of the task.

